### PR TITLE
상품 등록 & 특정 식재료 조회 API 수정

### DIFF
--- a/src/main/java/umc/aehopark/domain/product/controller/ProductController.java
+++ b/src/main/java/umc/aehopark/domain/product/controller/ProductController.java
@@ -41,9 +41,10 @@ public class ProductController {
 	@ResponseBody
 	@PostMapping("/register")
 	public ApiResponse<?> registerProduct(
+		@RequestParam long user_id,
 		@Validated @RequestBody ProductRequest request) {
 
-		ProductResponse response = productService.registerProduct(request);
+		ProductResponse response = productService.registerProduct(user_id, request);
 
 		return ApiResponse.onSuccess(response);
 	}

--- a/src/main/java/umc/aehopark/domain/product/repository/IngredientRepository.java
+++ b/src/main/java/umc/aehopark/domain/product/repository/IngredientRepository.java
@@ -15,9 +15,9 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
 	Optional<Ingredient> findByName(String name);
 
-	Page<Ingredient> findAllByName(PageRequest pageRequest, String name);
+	Page<Ingredient> findAllByNameContaining(PageRequest pageRequest, String name);
 
 	Page<Ingredient> findAllByCategory(PageRequest pageRequest, Category category);
 
-	Page<Ingredient> findAllByCategoryAndName(PageRequest pageRequest, Category category, String name);
+	Page<Ingredient> findAllByCategoryAndNameContaining(PageRequest pageRequest, Category category, String name);
 }

--- a/src/main/java/umc/aehopark/domain/product/repository/StoreRepository.java
+++ b/src/main/java/umc/aehopark/domain/product/repository/StoreRepository.java
@@ -1,8 +1,13 @@
 package umc.aehopark.domain.product.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import umc.aehopark.domain.product.entity.Store;
+import umc.aehopark.domain.user.entity.User;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
+
+	Optional<Store> findByUser(User user);
 }

--- a/src/main/java/umc/aehopark/domain/product/service/ProductService.java
+++ b/src/main/java/umc/aehopark/domain/product/service/ProductService.java
@@ -8,7 +8,7 @@ import umc.aehopark.domain.product.entity.Ingredient;
 
 public interface ProductService {
 	// 판매 상품 등록
-	public ProductResponse registerProduct(ProductRequest request);
+	public ProductResponse registerProduct(long user_id, ProductRequest request);
 
 	// 판매 상품 변경
 	public ProductResponse alterProduct(Long productId, ProductRequest request);

--- a/src/main/java/umc/aehopark/domain/product/service/ProductServiceImpl.java
+++ b/src/main/java/umc/aehopark/domain/product/service/ProductServiceImpl.java
@@ -15,11 +15,14 @@ import umc.aehopark.domain.product.entity.Category;
 import umc.aehopark.domain.product.entity.Ingredient;
 import umc.aehopark.domain.product.entity.Product;
 import umc.aehopark.domain.product.entity.ProductImage;
+import umc.aehopark.domain.product.entity.Store;
 import umc.aehopark.domain.product.handler.ProductHandler;
 import umc.aehopark.domain.product.repository.CategoryRepository;
 import umc.aehopark.domain.product.repository.IngredientRepository;
 import umc.aehopark.domain.product.repository.ProductImageRepository;
 import umc.aehopark.domain.product.repository.ProductRepository;
+import umc.aehopark.domain.product.repository.StoreRepository;
+import umc.aehopark.domain.user.entity.User;
 import umc.aehopark.domain.user.repository.UserRepository;
 import umc.aehopark.global.status.ErrorStatus;
 
@@ -29,6 +32,7 @@ import umc.aehopark.global.status.ErrorStatus;
 public class ProductServiceImpl implements ProductService {
 
 	private final UserRepository userRepository;
+	private final StoreRepository storeRepository;
 	private final ProductRepository productRepository;
 	private final IngredientRepository ingredientRepository;
 	private final CategoryRepository categoryRepository;
@@ -37,11 +41,11 @@ public class ProductServiceImpl implements ProductService {
 	// 판매 상품 등록
 	@Override
 	@Transactional
-	public ProductResponse registerProduct(ProductRequest request) {
+	public ProductResponse registerProduct(long userId, ProductRequest request) {
 
-		// 유저 아이디 존재 여부
-		// User user = userRepository.findById(request.userId)
-		// 	.orElseThrow(() -> new ProductHandler(ErrorStatus.USER_NOT_FOUND));
+		//유저 아이디 존재 여부
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new ProductHandler(ErrorStatus.USER_NOT_FOUND));
 
 		// 카테고리 존재 여부
 		if (!categoryRepository.existsByName(request.getCategory())) {
@@ -52,6 +56,9 @@ public class ProductServiceImpl implements ProductService {
 		Ingredient ingredient = ingredientRepository.findByName(request.getIngredientName())
 			.orElseThrow(() -> new ProductHandler(ErrorStatus.INGREDIENT_NOT_FOUND));
 
+		Store store = storeRepository.findByUser(user)
+			.orElseThrow(() -> new ProductHandler(ErrorStatus.STORE_NOT_FOUND));
+
 		Product newProduct = Product.builder()
 			.name(request.getName())
 			.content(request.getContents())
@@ -59,6 +66,7 @@ public class ProductServiceImpl implements ProductService {
 			.stock(0) // 기본 재고 설정
 			.deliveryFee(0) // 기본 배송비 설정
 			.ingredient(ingredient)
+			.store(store)
 			.build();
 
 		Product savedProduct = productRepository.save(newProduct);

--- a/src/main/java/umc/aehopark/domain/product/service/ProductServiceImpl.java
+++ b/src/main/java/umc/aehopark/domain/product/service/ProductServiceImpl.java
@@ -150,10 +150,14 @@ public class ProductServiceImpl implements ProductService {
 	@Override
 	public Page<Ingredient> searchProduct(String ingredientName, Integer page) {
 
-		ingredientRepository.findByName(ingredientName)
-			.orElseThrow(() -> new ProductHandler(ErrorStatus.INGREDIENT_NOT_FOUND));
+		Page<Ingredient> ingredientsPage = ingredientRepository.findAllByNameContaining(
+			PageRequest.of(page, 10), ingredientName);
 
-		return ingredientRepository.findAllByName(PageRequest.of(page, 10), ingredientName);
+		if (ingredientsPage.isEmpty()) {
+			throw new ProductHandler(ErrorStatus.INGREDIENT_NOT_FOUND);
+		}
+
+		return ingredientsPage;
 	}
 
 	// 카테고리별 모든 식재료 조회 + 페이징
@@ -173,10 +177,14 @@ public class ProductServiceImpl implements ProductService {
 		Category category = categoryRepository.findByName(categoryName)
 			.orElseThrow(() -> new ProductHandler(ErrorStatus.CATEGORY_NOT_FOUND));
 
-		ingredientRepository.findByName(ingredientName)
-			.orElseThrow(() -> new ProductHandler(ErrorStatus.INGREDIENT_NOT_FOUND));
+		Page<Ingredient> ingredientsPage = ingredientRepository.findAllByCategoryAndNameContaining(
+			PageRequest.of(page, 10), category, ingredientName);
 
-		return ingredientRepository.findAllByCategoryAndName(PageRequest.of(page, 10), category, ingredientName);
+		if (ingredientsPage.isEmpty()) {
+			throw new ProductHandler(ErrorStatus.INGREDIENT_NOT_FOUND);
+		}
+
+		return ingredientsPage;
 	}
 
 }

--- a/src/main/java/umc/aehopark/global/status/ErrorStatus.java
+++ b/src/main/java/umc/aehopark/global/status/ErrorStatus.java
@@ -27,6 +27,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품이 없습니다."),
 	INGREDIENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "검색한 식재료가 없습니다."),
 	CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "검색한 카테고리가 없습니다."),
+	STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "가게가 없습니다."),
 
 	FAIL_PARSE_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, "Apple Identity Token 헤더 파싱을 실패하였습니다."),
 	FAIL_PARSE_CLAIM(HttpStatus.BAD_REQUEST, "Claim을 파싱하는데 실패하였습니다."),


### PR DESCRIPTION
[ 상품 등록 ]
- user_id를 Query String으로 받아 Store 내용 가져온 뒤 등록하는 상품에 store_id 함께 기입

[ 특정 식재료 조회 ]
- 식재료 기입 시 관련 단어가 들어간 식재료 모두 조회
- 한 단어 입력 시 모든 식재료가 조회되는 현상 발생 => 같은 내용으로 한번 더 조회하면 관련 식재료 조회 성공
- 위의 내용에 대한 수정..? 필요할 시 수정 진행할 예정